### PR TITLE
Update python-publish.yml to exclude twine upload

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,9 +28,8 @@ jobs:
 
       - name: Build release distributions
         run: |
-          python -m pip install build twine
+          python -m pip install build
           python -m build
-          twine upload dist/*
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Removed twine upload step from the workflow.