### PR TITLE
Pull request overview Fixes a heuristic stop-condition bug where the bot wouldn’t stop on the same turn it first collects a worm.

### DIFF
--- a/pickomino_env/modules/bot.py
+++ b/pickomino_env/modules/bot.py
@@ -84,7 +84,8 @@ class Bot:
             action_dice = WORM_INDEX
 
         # 3. Quit as soon as you can take a tile: dice sum for a visible tile reached and worm collected.
-        if sum(np.multiply(collected, values)) + contribution[action_dice] >= smallest and collected[WORM_INDEX]:
+        worm_collected = bool(collected[WORM_INDEX]) or action_dice == WORM_INDEX
+        if sum(np.multiply(collected, values)) + contribution[action_dice] >= smallest and worm_collected:
             action_roll = ACTION_STOP
 
         return action_dice, action_roll


### PR DESCRIPTION
## Pull request overview

Fixes a heuristic stop-condition bug where the bot wouldn’t stop on the same turn it first collects a worm.

**Changes:**
- Introduced a `has_worm` flag that accounts for worms already collected or being collected this turn
- Updated the stop condition to use `has_worm` instead of only `collected[WORM_INDEX]`





---

💡 <a href="/smallgig/Pickomino/new/main/.github/instructions?filename=*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.