### PR TITLE
Add a console script entry point for manual play (#336)

### DIFF
--- a/pickomino_env/modules/play.py
+++ b/pickomino_env/modules/play.py
@@ -34,7 +34,8 @@ class ManualPlay:  # pylint: disable=too-few-public-methods.
             _, _, game_terminated, _, _ = env.step((selection, roll_choice))
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point for manual play."""
     manual_play = ManualPlay()
     # Keep offering to play until the user does not want to play again.
     while True:  # pylint: disable=while-used
@@ -45,3 +46,7 @@ if __name__ == "__main__":
         play_again: bool = bool(int(input("Play again? Enter '1', else '0': ")))
         if not play_again:
             break
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "pygame-ce>=2.5.2,<3.0.0",
 ]
 
+[project.scripts]
+pickomino-play = "pickomino_env.modules.play:main"
+
 [project.optional-dependencies]
 test = [
     "pytest>=8.3.5,<9.0.0",


### PR DESCRIPTION
## Description

GUI play can now be started with pickomino-play on the command line after environment is installed.

## Related Issue

Closes #336

## Changes

* Add main() function to play.py as entry point
* Add [project.scripts] pickomino-play entry to pyproject.toml.
* Updated slow tests.
* 
## Testing

- [x] Tests added/updated
- [x] Passes pre-commit hooks
- [x] Test coverage maintained (95%+)
