### PR TITLE
Fix package-data to include sprite files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you know the physical game, note the following simplifications:
   choose a lower-valued tile like in the physical game.
 - **Stealing:** always performed when possible, you cannot choose.
 - **Win condition:** determined correctly when playing manually with GUI (most worms win, ties
-  broken by the highest tile). When training without a renderer, no winner is declared
+  broken by the highest tile). When training without a renderer, no winner is declared;
   use total reward as your metric. But take care, stolen tiles do not reduce your reward,
   total reward can exceed your final score.
 - **Stack height:** not included in the observation (visible in the physical game).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ when to roll and when to stop.
 
 If you know the physical game, note the following simplifications:
 
-- **A Failed attempt:** the highest tile on the table is removed, not turned face-down.
+- **Failed Attempt:** the highest tile on the table is removed, not turned face-down.
 - **Tile selection:** the best reachable tile is always taken automatically, you cannot
   choose a lower-valued tile like in the physical game.
 - **Stealing:** always performed when possible, you cannot choose.

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ when to roll and when to stop.
 
 If you know the physical game, note the following simplifications:
 
-- **Failed attempt:** the highest tile on the table is removed, not turned face-down.
+- **A Failed attempt:** the highest tile on the table is removed, not turned face-down.
 - **Tile selection:** the best reachable tile is always taken automatically, you cannot
-choose a lower-valued tile like in the physical game.
+  choose a lower-valued tile like in the physical game.
 - **Stealing:** always performed when possible, you cannot choose.
-- **Win condition:** determined correctly when playing manually with GUI (most worms wins, ties
-broken by highest tile). When training without a renderer, no winner is declared
-use total reward as your metric. But take care, stolen tiles do not reduce your reward,
-total reward can exceed your final score.
+- **Win condition:** determined correctly when playing manually with GUI (most worms win, ties
+  broken by the highest tile). When training without a renderer, no winner is declared
+  use total reward as your metric. But take care, stolen tiles do not reduce your reward,
+  total reward can exceed your final score.
 - **Stack height:** not included in the observation (visible in the physical game).
 
 ## Action Space
@@ -161,18 +161,18 @@ These must be specified.
 The bots use the following heuristic, inspired by
 [Frozen Fractal's strategy](https://frozenfractal.com/blog/2015/5/3/how-to-win-at-pickomino/):
 
-- **Take the highest-contributing face.** Choose the die face where
-   `count × face value` is greatest. Worms count as 5.
+- **Take the highest-contributing face.** Select the die face where
+  `count × face value` is greatest. Worms count as 5.
 - **Tie-breaking.** When two faces contribute equally: prefer worms over 5s.
-   If still tied, prefer the face with the fewest dice keeping more dice
-   available for future rolls. Hence, for example, three 4s are preferred
-   over four 3s.
+  If still tied, prefer the face with the fewest dice keeping more dice
+  available for future rolls. Hence, for example, three 4s are preferred
+  over four 3s.
 - **Worm priority on early rolls.** If no dice have been collected yet and
-   this is the third roll or later, take worms if available, regardless of
-   contribution.
+  this is the third roll or later, take worms if available, regardless of
+  contribution.
 - **Stop as soon as a tile is reachable.** Once the running total meets or
-   exceeds the lowest available tile value and a worm has been collected,
-   the bot stops.
+  exceeds the lowest available tile value, and a worm has been collected,
+  the bot stops.
 
 ## Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pickomino-env"
-version = "1.4.0"
+version = "1.4.1"
 description = "Pickomino (Heckmeck) Gymnasium environment"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"  # Update ".python-version" when supporting a new version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=82", "wheel"]
+requires = ["setuptools>=82.0.1", "wheel>=0.47.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -23,8 +23,8 @@ test = [
     "pytest>=8.3.5,<9.0.0",
     "pytest-cov>=7.0,<8.0",
     "pytest-timeout>=2.0,<3.0",
-    "matplotlib>=3.0,<4.0",
-    "stable-baselines3>=2.3.0, <3.0",
+    "matplotlib>=3.10.9,<4.0",
+    "stable-baselines3>=2.8.0, <3.0",
 ]
 dev = ["loguru>=0.7.3,<1.0.0"]
 
@@ -53,7 +53,7 @@ fail_under = 95
 omit = ["config*.py"]
 
 [tool.setuptools.package-data]
-"pickomino" = ["py.typed"]
+"pickomino_env" = ["py.typed", "sprites/*.png"]
 
 [tool.ruff]
 line-length = 120
@@ -85,7 +85,7 @@ ignore = [
     "D203", # Conflicts with D211 (no blank line before class wins)
     "D213", # Conflicts with D212 (first line summary wins)
     "D413", # No blank line after docstring allowed (Google style).
-    "COM812", # Trailing comma missing, black wins
+    "COM812", # A trailing comma missing, black wins
 ]
 
 [tool.pylint.master]


### PR DESCRIPTION
Changed package name from "pickomino" to "pickomino_env" and added sprites/*.png to package-data. This fixes FileNotFoundError when running pickomino-play after installing from PyPI.

Fixes #394

## Description

add sprites/*.png

## Related Issue

Closes #394

## Changes

- add sprites/*.png to pyproject.toml
- Fixed white space and English in README.md
- Updates some tool versions in pyproject.toml
- Bumps version to 1.4.1 to release bug fix straight away

## Testing

Not applicable.