### PR TITLE
fix #342: Move mypy config to pyproject.toml and add mypy to CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,9 +35,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[test,dev]"
-          pip install pyright==1.1.408 ruff==0.14.13
+          pip install pyright==1.1.408 ruff==0.14.13 mypy==1.18.2
       - name: Lint with ruff
         run: ruff check . --exclude tests/,examples/
+      - name: Type check with mypy
+        run: mypy pickomino_env
       - name: Type check with Pyright
         run: pyright --project=pyproject.toml
       - name: Run pytest with coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v1.18.2
     hooks:
       - id: mypy
-        args: [ "--strict" ]
+        args: []
         additional_dependencies: [ "pickomino-env", "types-requests", "types-PyYAML", "gymnasium", "numpy", "pygame-ce", "loguru" ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,3 +142,24 @@ reportUnknownMemberType = "none"
 reportUnknownParameterType = "none"
 reportUnnecessaryIsInstance = "none"
 reportUnknownArgumentType = "none"
+
+[tool.mypy]
+strict = true
+allow_redefinition = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+no_implicit_optional = true
+pretty = true
+show_error_codes = true
+show_error_context = true
+show_traceback = true
+strict_equality = true
+strict_optional = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = false
+exclude = "^build/|^docs/"


### PR DESCRIPTION
Closes #342

## Changes
- Added `[tool.mypy]` section to `pyproject.toml` with strict configuration
- Removed `--strict` arg from mypy pre-commit hook (now reads from `pyproject.toml`)
- Added mypy install and type check step to `python-package.yml` CI workflow

## Notes
- `warn_unused_ignores = false` is intentional — preserves the `type: ignore[override]` on `render()` (tracked in #342 and #316)
- mypy version pinned to `1.18.2` in CI to match pre-commit hook version