### PR TITLE
#363 Replace magic numbers in Renderer._draw_dice with named constants

### DIFF
--- a/pickomino_env/modules/constants.py
+++ b/pickomino_env/modules/constants.py
@@ -27,7 +27,12 @@ __all__ = [
     "BUTTON_TEXT_COLOR",
     "BUTTON_WIDTH",
     "BUTTON_Y_OFFSET",
+    "DICE_COUNT_ROW_COLLECTED",
+    "DICE_COUNT_ROW_ROLLED",
     "DICE_FONT_SIZE",
+    "DICE_HOVER_BORDER_RADIUS",
+    "DICE_HOVER_BORDER_WIDTH",
+    "DICE_HOVER_OFFSET",
     "DICE_LABELS_OFFSET_Y",
     "DICE_LABELS_SPACING",
     "DICE_LABEL_COLLECTED",
@@ -35,6 +40,7 @@ __all__ = [
     "DICE_LABEL_WIDTH",
     "DICE_LABEL_X",
     "DICE_NAMES",
+    "DICE_SCORE_ROW_INDEX",
     "DICE_SECTION_START_Y",
     "DICE_SPACING",
     "DIE_SIZE",
@@ -167,6 +173,9 @@ DICE_LABEL_WIDTH: Final[int] = 100
 DICE_SPACING: Final[int] = (WINDOW_WIDTH - DICE_LABEL_WIDTH) // NUM_DIE_FACES
 
 # Dice counts.
+DICE_COUNT_ROW_COLLECTED: Final[int] = 0
+DICE_COUNT_ROW_ROLLED: Final[int] = 1
+DICE_SCORE_ROW_INDEX: Final[int] = 2
 DICE_LABEL_COLLECTED: Final[str] = "Collected:"
 DICE_LABEL_ROLLED: Final[str] = "Rolled:"
 DICE_LABELS_OFFSET_Y: Final[int] = 5  # Distance from dice image bottom to labels.
@@ -184,6 +193,9 @@ TILES_ROW_SPACING: Final[int] = -15
 TILES_START_X: Final[int] = 170
 TILES_START_Y: Final[int] = 480
 TILES_HOVER_COLOR: Final[tuple[int, int, int]] = (255, 255, 0)
+DICE_HOVER_OFFSET: Final[int] = 3
+DICE_HOVER_BORDER_WIDTH: Final[int] = 3
+DICE_HOVER_BORDER_RADIUS: Final[int] = 5
 
 # Display action.
 ACTION_DISPLAY_X: Final[int] = 20

--- a/pickomino_env/modules/renderer.py
+++ b/pickomino_env/modules/renderer.py
@@ -33,7 +33,12 @@ from pickomino_env.modules.constants import (
     BUTTON_Y_OFFSET,
     BUTTONS_START_X,
     BUTTONS_START_Y,
+    DICE_COUNT_ROW_COLLECTED,
+    DICE_COUNT_ROW_ROLLED,
     DICE_FONT_SIZE,
+    DICE_HOVER_BORDER_RADIUS,
+    DICE_HOVER_BORDER_WIDTH,
+    DICE_HOVER_OFFSET,
     DICE_LABEL_COLLECTED,
     DICE_LABEL_ROLLED,
     DICE_LABEL_WIDTH,
@@ -41,6 +46,7 @@ from pickomino_env.modules.constants import (
     DICE_LABELS_OFFSET_Y,
     DICE_LABELS_SPACING,
     DICE_NAMES,
+    DICE_SCORE_ROW_INDEX,
     DICE_SECTION_START_Y,
     DICE_SPACING,
     DIE_SIZE,
@@ -289,14 +295,25 @@ class Renderer:
             # Hover effect
             is_hovered = dice_rect.collidepoint(self._mouse_pos) or self._action_click_dice == index
             if is_hovered:
-                highlight_rect = pygame.Rect(x - 3, y - 3, DIE_SIZE + 6, DIE_SIZE + 6)
-                pygame.draw.rect(self._window, TILES_HOVER_COLOR, highlight_rect, width=3, border_radius=5)
+                highlight_rect = pygame.Rect(
+                    x - DICE_HOVER_OFFSET,
+                    y - DICE_HOVER_OFFSET,
+                    DIE_SIZE + 2 * DICE_HOVER_OFFSET,
+                    DIE_SIZE + 2 * DICE_HOVER_OFFSET,
+                )
+                pygame.draw.rect(
+                    self._window,
+                    TILES_HOVER_COLOR,
+                    highlight_rect,
+                    width=DICE_HOVER_BORDER_WIDTH,
+                    border_radius=DICE_HOVER_BORDER_RADIUS,
+                )
 
-        self._draw_dice_counts(0)  # Collected.
-        self._draw_dice_counts(1)  # Rolled.
+        self._draw_dice_counts(DICE_COUNT_ROW_COLLECTED)  # Collected.
+        self._draw_dice_counts(DICE_COUNT_ROW_ROLLED)  # Rolled.
 
         # Score label
-        score_y = DICE_SECTION_START_Y + DIE_SIZE + DICE_LABELS_OFFSET_Y + 2 * DICE_LABELS_SPACING
+        score_y = DICE_SECTION_START_Y + DIE_SIZE + DICE_LABELS_OFFSET_Y + DICE_SCORE_ROW_INDEX * DICE_LABELS_SPACING
         score_text = f"Score: {self._game.dice.score()[0]}"
         score_text_surface = True
         score_surface = self._dice_font.render(score_text, score_text_surface, FONT_COLOR)
@@ -309,7 +326,7 @@ class Renderer:
 
         # Draw labels.
         labels_y: int = DICE_SECTION_START_Y + DIE_SIZE + DICE_LABELS_OFFSET_Y + row_index * DICE_LABELS_SPACING
-        if row_index == 0:  # Collected.
+        if row_index == DICE_COUNT_ROW_COLLECTED:
             label: str = DICE_LABEL_COLLECTED
             counts: list[int] = self._game.dice.get_collected()
         else:  # Rolled.

--- a/pickomino_env/pickomino.py
+++ b/pickomino_env/pickomino.py
@@ -196,7 +196,7 @@ class PickominoEnv(gym.Env):  # type: ignore[type-arg]
         self.render_mode = render_mode
         self._renderer = Renderer(self.render_mode)
 
-    def render(  # type: ignore[override]
+    def render(
         self,
     ) -> NDArray[np.uint8] | None:
         """Render the current game state.


### PR DESCRIPTION
## Description
Replace magic numbers in Renderer._draw_dice with named constants in constants.py.

## Related Issue
Closes #363

## Changes
- Added DICE_COUNT_ROW_COLLECTED, DICE_COUNT_ROW_ROLLED, DICE_SCORE_ROW_INDEX, DICE_HOVER_OFFSET, DICE_HOVER_BORDER_WIDTH, DICE_HOVER_BORDER_RADIUS to constants.py and __all__
- Replaced all magic numbers in Renderer._draw_dice and _draw_dice_counts with the new constants
- Removed unused type: ignore[override] comment in pickomino.py

## Testing
- [ ] Tests added/updated
- [ ] Passes pre-commit hooks
- [ ] Test coverage maintained (95%+)