### PR TITLE
#405 Add release-drafter workflow and config for automated changelog …

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,40 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Added"
+    labels:
+      - "enhancement"
+  - title: "Changed"
+    labels:
+      - "technical dept / refactoring"
+      - "Continuous Integration"
+      - "documentation"
+  - title: "Fixed"
+    labels:
+      - "bug"
+
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+
+exclude-labels:
+  - "skip-changelog"
+  - "nice to have"
+  - "Pedantic"
+
+template: |
+  ## [Unreleased]
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+# Automatically drafts release notes as pull requests are merged into main.
+# Uses release-drafter to categorize changes based on PR labels.
+# See .github/release-drafter.yml for label-to-category mapping.
+
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pickomino_env/pickomino.py
+++ b/pickomino_env/pickomino.py
@@ -196,7 +196,7 @@ class PickominoEnv(gym.Env):  # type: ignore[type-arg]
         self.render_mode = render_mode
         self._renderer = Renderer(self.render_mode)
 
-    def render(  # type: ignore[override]
+    def render(
         self,
     ) -> NDArray[np.uint8] | None:
         """Render the current game state.


### PR DESCRIPTION
## Description
Add release-drafter GitHub Action to automate changelog drafting as pull requests are merged into main.

## Related Issue
Closes #405

## Changes
- Added .github/release-drafter.yml with category mapping matching existing CHANGELOG.md format (Added, Changed, Fixed)
- Added .github/workflows/release-drafter.yml workflow triggered on push and PR to main
- Labels mapped: enhancement → Added, technical dept / refactoring + Continuous Integration + documentation → Changed, bug → Fixed
- PRs labelled nice to have and Pedantic are excluded from changelog drafts
- Removed unused type: ignore[override] comment in pickomino.py

## Testing
- [ ] Tests added/updated
- [ ] Passes pre-commit hooks
- [ ] Test coverage maintained (95%+)